### PR TITLE
Fixing

### DIFF
--- a/main/run.py
+++ b/main/run.py
@@ -47,8 +47,7 @@ def authentificate():
         session_id = soup.sessionId.string
         print("User successfully authentified.")
     except Exception as e:
-        print("Authentification failed:")
-        print(e)
+        print("Authentification failed: username or password are not correct.")
         session_id = ''
     return session_id
 

--- a/main/run.py
+++ b/main/run.py
@@ -281,12 +281,13 @@ else:
                                 create_directory(xslt_output)
                                 xslt_output = "-o:" + xslt_output
                                 xslt_input = "-s:" + xslt_input
-                                subprocess.call(["java", "-jar", path_to_parser, xslt_input, xslt_output, path_to_xslt], env=env)
-                                errors += 1
+                                result = subprocess.call(["java", "-jar", path_to_parser, xslt_input, xslt_output, path_to_xslt], env=env)
+                                if not result == 0:
+                                	errors += 1
                         if errors == 0:
                             print("Successfully transformed exported PAGE XML files to TEI XML!")
                         else:
-                            print("Encountered errors while transforming exported XML files to TEI XML!")
+                            print("Errors encountered while transforming exported XML files to TEI XML!")
                     print("Files are stored in %s directory." % path_to_export_dir)
 
 


### PR DESCRIPTION
A control on the execution of subprocess.call() was poorly built.
Error message for failed authentication needed to be clearer.